### PR TITLE
Fixed missing else

### DIFF
--- a/system/libraries/Router.lc
+++ b/system/libraries/Router.lc
@@ -152,7 +152,7 @@ local sRoutes, sDefaultController, sDirectory, sScaffoldingRequest, sModuleRoute
  		if sDefaultController is FALSE then
  			rigShowError "Unable to determine what should be displayed. A default route has not been specified in the routing file."
  		end if
-
+  else
     if sDefaultController contains "/" then
       put sDefaultController into tX
       put item -1 of tX into tController


### PR DESCRIPTION
In order to handle default routes where revigniter is not at the root of the a web structure, an else needs to be added to correctly set the default controller. This appears to be a regression bug introduced when modules were added.