### PR TITLE
Fix problem making the framework to fail finding the default controller

### DIFF
--- a/system/libraries/Router.livecodescript
+++ b/system/libraries/Router.livecodescript
@@ -462,7 +462,7 @@ private function _rigValidateRequest pSegmentsArray
 			# DOES THE DEFAULT CONTROLLER EXIST IN THE SUB-FOLDER?
 			if there is a file (gRigA["APPPATH"] & rigFetchDirectory() & sRouterA["defaultController"] & gRigA["EXT"]) then
 				put "" into sRouterA["directory"]
-				put "" into tTemp[1]
+				put "" into tTemp
 				return tTemp
 			end if
 


### PR DESCRIPTION
### Description of the Change or Addition

<!--

This change only makes tTemp to the empty string, this way Router won't fail to select the default controller

-->

### Possible Side-Effects

-

### Verification

<!--

It worked like a charm after the change

-->
